### PR TITLE
Add a custom swap fn to preserve atomicity in custom onChange (per #11)

### DIFF
--- a/dev/leva/notebook.clj
+++ b/dev/leva/notebook.clj
@@ -274,9 +274,9 @@
 
 ;; #### Explicit `swap!` function for atom and onChange
 
-;; If you pass an :atom, any explicit :onChange callback is ignored. To control
-;; how atom state updates, instead pass an :on-swap function of three arguments
-;; to replace the default `(swap! atom k v)` behavior.
+;; If you pass an :atom, any explicit :onChange callback is ignored. Pass an
+;; :on-swap function to transform the atom state as part of the call to `swap!`
+;; to handle changes explicitly.
 
 ;; This example shows a SubPanel that uses a custom swap function to synchronize
 ;; two sliders with values summing to `1.0`:
@@ -284,20 +284,20 @@
 (show-sci
 
   ; Custom swap logic depending on the changed key
-  (defmulti  on-swap (fn [!state key value] key))
-  (defmethod on-swap :default [!s k v] (swap! !s assoc k v))
-  (defmethod on-swap :p-x     [!s _ v] (swap! !s assoc :p-x v :p-not-x (- 1.0 v)))
-  (defmethod on-swap :p-not-x [!s _ v] (swap! !s assoc :p-not-x v :p-x (- 1.0 v)))
+  (defmulti  on-swap (fn [state key old-value value] key))
+  (defmethod on-swap :p-x     [s _ _ v] (assoc s :p-not-x (- 1.0 v)))
+  (defmethod on-swap :p-not-x [s _ _ v] (assoc s :p-x (- 1.0 v)))
 
   (reagent/with-let
     [!local (reagent/atom {:p-x 0.80 :p-not-x 0.20})]
     [:div {:style {:width "60%" :margin "auto"}}
      [leva/SubPanel {:fill true :titleBar {:drag false}}
       [leva/Controls
-       {:schema  {:p-x     {:label "P(x)" :min 0 :max 1 :step 0.01}
-                  :p-not-x {:label "P(¬x)" :min 0 :max 1 :step 0.01}}
-        :atom    !local
-        :on-swap on-swap}]]]))
+       {:schema  {:p-x     {:label "P(x)" :min 0 :max 1 :step 0.01
+                            :on-swap on-swap}
+                  :p-not-x {:label "P(¬x)" :min 0 :max 1 :step 0.01
+                            :on-swap on-swap}}
+        :atom    !local}]]]))
 
 
 ;; ### Standard Inputs

--- a/src/leva/schema.cljs
+++ b/src/leva/schema.cljs
@@ -16,14 +16,18 @@
   "Given some atom `!state`, returns a function that accepts some `key` and
   returns a Leva OnChangeHandler that sets the entry in `!state` for `key` to
   the new incoming value."
-  [!state swapf]
+  [!state schema]
   (if !state
     (fn k->on-change [k]
-      (fn on-change [value _path _context]
-        (let [state (.-state !state)
-              v     (->clj value)]
-          (when (not= v (get state k ::not-found))
-            (swapf !state k v)))))
+      (let [on-swap (get-in schema [k :on-swap] identity)]
+        (fn on-change [value _path _context]
+          (let [state (.-state !state)
+                v     (->clj value)
+                old-v (get state k ::not-found)]
+            (when (not= v old-v)
+              (swap! !state
+                (fn [old-state]
+                  (on-swap (assoc old-state k v) k old-v v))))))))
     (fn [_k] (fn [_ _ _]))))
 
 (defn controlled->js
@@ -210,8 +214,8 @@
   The parsing logic [lives
   here](https://github.com/pmndrs/leva/blob/33b2d9948818c5828409e3cf65baed4c7492276a/packages/leva/src/useControls.ts#L30-L75)
   in leva."
-  [{:keys [folder schema atom store on-swap]}]
-  (let [k->on-change  (on-change-fn atom (or on-swap #(swap! %1 assoc %2 %3)))
+  [{:keys [folder schema atom store]}]
+  (let [k->on-change  (on-change-fn atom schema)
         initial-state (if atom (.-state atom) {})
         ;; NOTE This function wrapper is required for `set` to work
         ;; in [[leva.core/Controls]]. If you don't want to synchronize state


### PR DESCRIPTION
Adds a new :on-swap option as discussed [here](https://github.com/mentat-collective/Leva.cljs/issues/11#issuecomment-1479876110) to allow controlling how changes to one input update the entire state.

I called it :on-swap, but please feel free to change the name, or comment with an alternative and I'll update the PR. 

For example:
```clojure
(defonce state (r/atom {:p-x 0.8 :p-not-x 0.2}))

(defmulti  on-swap (fn [!state key value] key))
(defmethod on-swap :default [!s k v] (swap! !s assoc k v))
(defmethod on-swap :p-x     [!s _ v] (swap! !s assoc :p-x v :p-not-x (- 1 v)))
(defmethod on-swap :p-not-x [!s _ v] (swap! !s assoc :p-not-x v :p-x (- 1 v)))

(defn app []
  [leva-cljs/SubPanel {:fill true :titleBar {:drag false}}
   [leva-cljs/Controls
    {:folder    {:name "Controls"}
     :atom      state
     :schema    {:p-x     {:label "P(x)"  :min 0 :max 1 :step 0.01}
                 :p-not-x {:label "P(¬x)" :min 0 :max 1 :step 0.01}}
     :on-swap   on-swap}]])
```