### PR TITLE
Remove goog.object, SCI + Portal compatibility

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,15 +20,11 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@4.0
+        uses: DeLaGuardo/setup-clojure@master
         with:
           cli: latest
+          bb: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install babashka
-        uses: just-sultanov/setup-babashka@v2
-        with:
-          version: '0.8.156'
 
       - name: Build static site
         run: bb build-static

--- a/.github/workflows/kondo.yml
+++ b/.github/workflows/kondo.yml
@@ -12,16 +12,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install clojure tools
-        uses: DeLaGuardo/setup-clojure@master
+      - name: Install Babashka
+        uses: DeLaGuardo/setup-clojure@10.2
         with:
-          cli: latest
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install babashka
-        uses: just-sultanov/setup-babashka@v2
-        with:
-          version: '0.8.156'
+          bb: latest
 
       - name: Cache kondo directory
         uses: actions/cache@v2
@@ -30,5 +24,8 @@ jobs:
           key: ${{ runner.os }}-kondo
           restore-keys: ${{ runner.os }}-kondo
 
-      - name: Run clj-kondo
+      - name: Lint dependencies
+        run: bb lint-deps
+
+      - name: Lint project files
         run: bb lint --config '{:output {:pattern "::{{level}} file={{filename}},line={{row}},col={{col}}::{{message}}"}}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [unreleased]
 
+## [0.3.0]
+
+- #16:
+
+  - removes the `goog.object` to make the library compatible with SCI
+    evaluation, needed by Portal.
+
+  - adds various build upgrades, (Clerk, Kondo etc)
+
 - #12 fixes #10 by turning `SubPanel` into a wrapper that properly calls (with
   `:f>`) a new `SubPanel*` function component.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Think of your GUI like an interactive, beautiful view onto your page's state.
 
 ## Quickstart
 
-Install `Leva.cljs` into your Clojurescript project using the instructions at
+Install `Leva.cljs` into your ClojureScript project using the instructions at
 its Clojars page:
 
 [![Clojars Project][clojars]][clojars-url]

--- a/bb.edn
+++ b/bb.edn
@@ -1,9 +1,9 @@
 {:deps {org.babashka/http-server {:mvn/version "0.1.11"}
-        org.babashka/cli {:mvn/version "0.2.23"}}
- :pods {clj-kondo/clj-kondo {:version "2023.01.20"}}
+        org.babashka/cli {:mvn/version "0.2.23"}
+        io.github.clj-kondo/clj-kondo-bb
+        {:git/tag "v2023.01.20" :git/sha "adfc7df"}}
  :tasks
- {:requires ([babashka.cli :as cli]
-             [pod.borkdude.clj-kondo :as clj-kondo])
+ {:requires ([babashka.cli :as cli])
   :init
   (do (def cli-opts
         (cli/parse-opts *command-line-args* {:coerce {:port :int}}))
@@ -51,7 +51,16 @@
   {:doc "Release the library to Clojars."
    :task (shell "clojure -T:build publish")}
 
+  lint-deps
+  {:requires ([clj-kondo.core :as kondo])
+   :doc "Lint dependencies."
+   :task (kondo/run!
+          {:lint [(with-out-str
+                    (babashka.tasks/clojure
+                     "-Spath -A:nextjournal/clerk"))]
+           :dependencies true})}
+
   lint
   {:doc "Lint the src and dev directories with clj-kondo."
-   :task (clj-kondo/print!
-          (clj-kondo/run! {:lint ["src" "dev"]}))}}}
+   :task (exec 'clj-kondo.core/exec)
+   :exec-args {:lint ["src" "dev"]}}}}

--- a/build.clj
+++ b/build.clj
@@ -17,7 +17,7 @@
 ;; ## Variables
 
 (def lib 'org.mentat/leva.cljs)
-(def version "0.2.2")
+(def version "0.3.0")
 (def pom-deps
   {'org.babashka/sci
    {:mvn/version "0.6.37"

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps {reagent/reagent {:mvn/version "1.1.1"}}
+ :deps {reagent/reagent {:mvn/version "1.2.0"}}
 
  :aliases
  {:nextjournal/clerk
@@ -7,17 +7,17 @@
    :extra-deps
    {org.clojure/clojure       {:mvn/version "1.11.1"}
     org.clojure/clojurescript {:mvn/version "1.11.60"}
-    org.mentat/clerk-utils    {:mvn/version "0.4.1"}
+    org.mentat/clerk-utils    {:mvn/version "0.6.0"}
 
     io.github.nextjournal/clerk
-    {:git/sha "fad499407d979916d21b33cc7e46e73f7a485e37"}
+    {:git/sha "1f6c5331418aaf9c5a4335fc2e6e95f07dc3af6b"}
     io.github.nextjournal/clerk.render
     {:git/url "https://github.com/nextjournal/clerk"
-     :git/sha "fad499407d979916d21b33cc7e46e73f7a485e37"
+     :git/sha "1f6c5331418aaf9c5a4335fc2e6e95f07dc3af6b"
      :deps/root "render"}}
    :exec-fn user/build!}
 
   :build
-  {:deps {io.github.clojure/tools.build {:git/tag "v0.8.2" :git/sha "ba1a2bf"}
+  {:deps {io.github.clojure/tools.build {:git/tag "v0.9.4" :git/sha "76b78fe"}
           slipset/deps-deploy {:mvn/version "0.2.0"}}
    :ns-default build}}}

--- a/dev/leva/notebook.clj
+++ b/dev/leva/notebook.clj
@@ -720,7 +720,7 @@
 ;;
 ;; `Leva.cljs` includes
 ;; a [`deps-new`](https://github.com/seancorfield/deps-new) template called
-;; [`leva/clerk`](https://github.com/mentat-collective/clerk-utils/tree/main/resources/clerk_utils/custom)
+;; [`leva/clerk`](https://github.com/mentat-collective/leva.cljs/tree/main/resources/leva/clerk)
 ;; that makes it easy to configure a new Clerk project with everything described
 ;; in ["Leva.cljs via SCI"](#leva.cljs-via-sci) already configured.
 

--- a/dev/leva/notebook.clj
+++ b/dev/leva/notebook.clj
@@ -1,9 +1,6 @@
-^#:nextjournal.clerk
-{:toc true
- :no-cache true
- :visibility :hide-ns}
+^{:nextjournal.clerk/visibility {:code :hide}}
 (ns leva.notebook
-  {:nextjournal.clerk/auto-expand-results? true}
+  #:nextjournal.clerk{:toc true :no-cache true}
   (:require [mentat.clerk-utils.docs :as docs]
             [mentat.clerk-utils.show :refer [show-sci]]
             [nextjournal.clerk :as clerk]))
@@ -11,8 +8,8 @@
 ^{::clerk/visibility {:code :hide :result :hide}}
 (clerk/eval-cljs
  ;; These aliases only apply inside this namespace.
- '(require '[leva.core :as leva])
- '(require '[reagent.core :as reagent]))
+ '(do (require '[leva.core :as leva])
+      (require '[reagent.core :as reagent])))
 
 ;; # Leva.cljs
 ;;

--- a/src/leva/schema.cljs
+++ b/src/leva/schema.cljs
@@ -2,8 +2,7 @@
   "Functions for converting a leva.cljs schema into a Leva schema set up for state
   synchronization via a ClojureScript atom."
   (:require ["leva" :as l]
-            [leva.types :as t]
-            [goog.object :as o]))
+            [leva.types :as t]))
 
 (defn ->clj
   "Slightly more efficient `js->clj` that skips primitive types."
@@ -91,7 +90,7 @@
   [acc m k->on-change]
   (letfn [(process [acc k v]
             (doto acc
-              (o/set
+              (aset
                (name k)
                (controlled->js k v {} (k->on-change k)))))]
     (reduce-kv process acc m)))
@@ -129,7 +128,7 @@
 
             (insert! [acc k v]
               (swap! seen conj k)
-              (doto acc (o/set (name k) v)))
+              (doto acc (aset (name k) v)))
             (rec [schema]
               (reduce-kv
                (fn [acc k entry]

--- a/src/leva/types.cljs
+++ b/src/leva/types.cljs
@@ -1,6 +1,5 @@
 (ns leva.types
-  (:require ["leva" :as l]
-            [goog.object :as o]))
+  (:require ["leva" :as l]))
 
 ;; ## Types and Schema Predicates
 ;;


### PR DESCRIPTION
- #16:

  - removes the `goog.object` to make the library compatible with SCI
    evaluation, needed by Portal.

  - adds various build upgrades, (Clerk, Kondo etc)

- #12 fixes #10 by turning `SubPanel` into a wrapper that properly calls (with
  `:f>`) a new `SubPanel*` function component.